### PR TITLE
Fix cross-platform build compatibility issues

### DIFF
--- a/Flex.UiWpfFramework/Flex.UiWpfFramework.csproj
+++ b/Flex.UiWpfFramework/Flex.UiWpfFramework.csproj
@@ -3,6 +3,12 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Flex.UiWpfFramework</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="obj\**\*.cs" />
+  </ItemGroup>
 
 </Project>

--- a/NetKeyer.csproj
+++ b/NetKeyer.csproj
@@ -44,6 +44,10 @@
     <ProjectReference Include="FlexLib\FlexLib.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="obj\**\*.cs" />
+  </ItemGroup>
+
   <!-- Copy OpenAL native DLLs to output directory -->
   <Target Name="CopyOpenALNative" AfterTargets="Build;Publish">
     <PropertyGroup>

--- a/build-installer.ps1
+++ b/build-installer.ps1
@@ -29,6 +29,8 @@ if (-not $vpkInstalled) {
 # Step 2: Clean previous builds
 Write-Host "`n[2/5] Cleaning previous builds..." -ForegroundColor Yellow
 dotnet clean -c Release
+# Remove all obj and bin directories to prevent cross-platform build contamination
+Get-ChildItem -Path . -Include "obj","bin" -Recurse -Directory -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 Get-ChildItem -Path . -Filter "publish-*" -Directory | Remove-Item -Recurse -Force
 if (Test-Path "Releases") { Remove-Item -Recurse -Force "Releases" }
 

--- a/build-installer.sh
+++ b/build-installer.sh
@@ -25,6 +25,8 @@ fi
 # Step 2: Clean previous builds
 echo -e "\n\033[1;33m[2/5] Cleaning previous builds...\033[0m"
 dotnet clean -c Release
+# Remove all obj and bin directories to prevent cross-platform build contamination
+find . -type d \( -name "obj" -o -name "bin" \) -exec rm -rf {} + 2>/dev/null || true
 rm -rf publish-* Releases
 
 # Function to build for a specific platform


### PR DESCRIPTION
Resolves duplicate TargetFrameworkAttribute errors that occurred when building for different platforms sequentially (e.g., Windows then Linux).

Changes:
- Add `<Compile Remove="obj\**\*.cs" />` to NetKeyer.csproj and Flex.UiWpfFramework.csproj to exclude auto-generated source files from obj/ directories
- Add GenerateAssemblyInfo and GenerateTargetFrameworkAttribute settings to Flex.UiWpfFramework.csproj for consistency with other projects
- Enhanced build scripts to aggressively clean all obj/ and bin/ directories before building to prevent build artifact contamination between different platform builds

The root cause was that .NET generates temporary source files (including assembly attributes) in obj/ directories during builds. When switching between different RuntimeIdentifiers or platforms, these files would persist and be incorrectly picked up as source files, causing duplicate attribute errors. Other projects (FlexLib, Util, Vita) already had this exclusion in place.