### PR TITLE
configurable MIDI note mapping

### DIFF
--- a/Models/MidiNoteMapping.cs
+++ b/Models/MidiNoteMapping.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NetKeyer.Models
+{
+    [Flags]
+    public enum MidiNoteFunction
+    {
+        None = 0,
+        LeftPaddle = 1,
+        RightPaddle = 2,
+        StraightKey = 4,
+        PTT = 8
+    }
+
+    public class MidiNoteMapping
+    {
+        public int NoteNumber { get; set; }
+        public MidiNoteFunction Functions { get; set; }
+
+        public MidiNoteMapping()
+        {
+        }
+
+        public MidiNoteMapping(int noteNumber, MidiNoteFunction functions)
+        {
+            NoteNumber = noteNumber;
+            Functions = functions;
+        }
+
+        public bool HasFunction(MidiNoteFunction function)
+        {
+            return (Functions & function) != 0;
+        }
+
+        public static List<MidiNoteMapping> GetDefaultMappings()
+        {
+            return new List<MidiNoteMapping>
+            {
+                new MidiNoteMapping(20, MidiNoteFunction.LeftPaddle | MidiNoteFunction.StraightKey | MidiNoteFunction.PTT),
+                new MidiNoteMapping(21, MidiNoteFunction.RightPaddle | MidiNoteFunction.StraightKey | MidiNoteFunction.PTT),
+                new MidiNoteMapping(30, MidiNoteFunction.StraightKey),
+                new MidiNoteMapping(31, MidiNoteFunction.PTT)
+            };
+        }
+    }
+}

--- a/Models/UserSettings.cs
+++ b/Models/UserSettings.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -13,6 +15,9 @@ namespace NetKeyer.Models
         public string SelectedSerialPort { get; set; }
         public string SelectedMidiDevice { get; set; }
         public string InputType { get; set; } = "Serial";
+
+        // MIDI note mappings
+        public List<MidiNoteMapping> MidiNoteMappings { get; set; }
 
         // SmartLink settings
         public string SmartLinkClientId { get; set; }
@@ -197,6 +202,12 @@ namespace NetKeyer.Models
                         settings._smartLinkRefreshToken = DecryptString(settings.SmartLinkRefreshTokenEncrypted);
                     }
 
+                    // Load default MIDI note mappings if not present
+                    if (settings.MidiNoteMappings == null || settings.MidiNoteMappings.Count == 0)
+                    {
+                        settings.MidiNoteMappings = MidiNoteMapping.GetDefaultMappings();
+                    }
+
                     return settings;
                 }
             }
@@ -205,7 +216,9 @@ namespace NetKeyer.Models
                 Console.WriteLine($"Error loading settings: {ex.Message}");
             }
 
-            return new UserSettings();
+            var newSettings = new UserSettings();
+            newSettings.MidiNoteMappings = MidiNoteMapping.GetDefaultMappings();
+            return newSettings;
         }
 
         public void Save()

--- a/ViewModels/MidiConfigDialogViewModel.cs
+++ b/ViewModels/MidiConfigDialogViewModel.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NetKeyer.Models;
+
+namespace NetKeyer.ViewModels
+{
+    public partial class MidiNoteConfigRow : ObservableObject
+    {
+        [ObservableProperty]
+        private int _noteNumber;
+
+        [ObservableProperty]
+        private bool _isLeftPaddle;
+
+        [ObservableProperty]
+        private bool _isRightPaddle;
+
+        [ObservableProperty]
+        private bool _isStraightKey;
+
+        [ObservableProperty]
+        private bool _isPtt;
+
+        public MidiNoteConfigRow(int noteNumber)
+        {
+            NoteNumber = noteNumber;
+        }
+
+        public MidiNoteFunction GetFunctions()
+        {
+            var functions = MidiNoteFunction.None;
+            if (IsLeftPaddle) functions |= MidiNoteFunction.LeftPaddle;
+            if (IsRightPaddle) functions |= MidiNoteFunction.RightPaddle;
+            if (IsStraightKey) functions |= MidiNoteFunction.StraightKey;
+            if (IsPtt) functions |= MidiNoteFunction.PTT;
+            return functions;
+        }
+
+        public void SetFunctions(MidiNoteFunction functions)
+        {
+            IsLeftPaddle = (functions & MidiNoteFunction.LeftPaddle) != 0;
+            IsRightPaddle = (functions & MidiNoteFunction.RightPaddle) != 0;
+            IsStraightKey = (functions & MidiNoteFunction.StraightKey) != 0;
+            IsPtt = (functions & MidiNoteFunction.PTT) != 0;
+        }
+    }
+
+    public partial class MidiConfigDialogViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private ObservableCollection<MidiNoteConfigRow> _noteConfigurations = new();
+
+        [ObservableProperty]
+        private int? _selectedNoteNumber = 20;
+
+        [ObservableProperty]
+        private string _addNoteError = "";
+
+        public MidiConfigDialogViewModel()
+        {
+        }
+
+        public void LoadMappings(List<MidiNoteMapping> mappings)
+        {
+            NoteConfigurations.Clear();
+
+            // Create a lookup of existing mappings
+            var mappingDict = mappings.ToDictionary(m => m.NoteNumber, m => m.Functions);
+
+            // Add all configured notes
+            foreach (var mapping in mappings.OrderBy(m => m.NoteNumber))
+            {
+                var row = new MidiNoteConfigRow(mapping.NoteNumber);
+                row.SetFunctions(mapping.Functions);
+                NoteConfigurations.Add(row);
+            }
+        }
+
+        public List<MidiNoteMapping> GetMappings()
+        {
+            var mappings = new List<MidiNoteMapping>();
+
+            foreach (var row in NoteConfigurations)
+            {
+                var functions = row.GetFunctions();
+                if (functions != MidiNoteFunction.None)
+                {
+                    mappings.Add(new MidiNoteMapping(row.NoteNumber, functions));
+                }
+            }
+
+            return mappings;
+        }
+
+        [RelayCommand]
+        private void AddNote()
+        {
+            // Clear previous error
+            AddNoteError = "";
+
+            // Validate that a note number was entered
+            if (!SelectedNoteNumber.HasValue)
+            {
+                AddNoteError = "Please enter a note number";
+                return;
+            }
+
+            int noteNumber = SelectedNoteNumber.Value;
+
+            // Validate note number range
+            if (noteNumber < 0 || noteNumber > 127)
+            {
+                AddNoteError = "Note number must be between 0 and 127";
+                return;
+            }
+
+            // Check if note already exists
+            if (NoteConfigurations.Any(n => n.NoteNumber == noteNumber))
+            {
+                AddNoteError = $"Note {noteNumber} is already in the list";
+                return;
+            }
+
+            var newRow = new MidiNoteConfigRow(noteNumber);
+
+            // Insert in sorted order
+            int insertIndex = 0;
+            for (int i = 0; i < NoteConfigurations.Count; i++)
+            {
+                if (NoteConfigurations[i].NoteNumber > noteNumber)
+                {
+                    break;
+                }
+                insertIndex = i + 1;
+            }
+
+            NoteConfigurations.Insert(insertIndex, newRow);
+
+            // Clear the input and error after successful add
+            SelectedNoteNumber = null;
+        }
+
+        [RelayCommand]
+        private void RemoveNote(MidiNoteConfigRow row)
+        {
+            if (row != null)
+            {
+                NoteConfigurations.Remove(row);
+            }
+        }
+
+        [RelayCommand]
+        private void ResetToDefaults()
+        {
+            LoadMappings(MidiNoteMapping.GetDefaultMappings());
+        }
+    }
+}

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -112,9 +112,16 @@
                                         Padding="4"/>
                             </StackPanel>
 
-                            <TextBlock Text="Note: MIDI uses Note 20 (Left Paddle) and Note 21 (Right Paddle)"
-                                       FontSize="10"
-                                       Foreground="Gray"/>
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <Button Content="Configure MIDI Notes..."
+                                        Command="{Binding ConfigureMidiNotesCommand}"
+                                        Width="180"
+                                        Padding="4"/>
+                                <TextBlock Text="Configure which MIDI notes control paddles, straight key, and PTT"
+                                           FontSize="10"
+                                           Foreground="Gray"
+                                           VerticalAlignment="Center"/>
+                            </StackPanel>
                         </StackPanel>
                     </StackPanel>
                 </Border>

--- a/Views/MidiConfigDialog.axaml
+++ b/Views/MidiConfigDialog.axaml
@@ -1,0 +1,168 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:NetKeyer.ViewModels"
+        x:Class="NetKeyer.Views.MidiConfigDialog"
+        x:DataType="vm:MidiConfigDialogViewModel"
+        Title="MIDI Note Configuration"
+        Width="650" Height="550"
+        MinWidth="650" MinHeight="450"
+        WindowStartupLocation="CenterOwner"
+        CanResize="true">
+
+    <Grid Margin="15" RowDefinitions="Auto,Auto,*,Auto,Auto">
+
+        <!-- Title and Instructions -->
+        <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,15">
+            <TextBlock Text="MIDI Note Configuration"
+                       FontSize="18"
+                       FontWeight="Bold"/>
+            <TextBlock Text="Assign MIDI notes (0-127) to one or more functions. Multiple functions can be assigned to the same note."
+                       FontSize="12"
+                       Foreground="Gray"
+                       TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <!-- Add Note Section -->
+        <Border Grid.Row="1"
+                BorderBrush="Gray"
+                BorderThickness="1"
+                Padding="10"
+                CornerRadius="3"
+                Margin="0,0,0,10">
+            <StackPanel Spacing="6">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <TextBlock Text="Add Note:"
+                               VerticalAlignment="Center"
+                               FontWeight="SemiBold"/>
+                    <NumericUpDown Value="{Binding SelectedNoteNumber}"
+                                   Minimum="0"
+                                   Maximum="127"
+                                   Width="120"
+                                   ShowButtonSpinner="True"
+                                   FormatString="0"
+                                   AllowSpin="True"
+                                   ParsingNumberStyle="Integer"/>
+                    <Button Content="Add"
+                            Command="{Binding AddNoteCommand}"
+                            Width="60"
+                            Padding="5"/>
+                    <TextBlock Text="(MIDI note 0-127)"
+                               VerticalAlignment="Center"
+                               FontSize="11"
+                               Foreground="Gray"/>
+                </StackPanel>
+                <TextBlock Text="{Binding AddNoteError}"
+                           Foreground="Red"
+                           FontSize="11"
+                           IsVisible="{Binding AddNoteError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           Margin="0,0,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Note Configurations Table -->
+        <Border Grid.Row="2"
+                BorderBrush="Gray"
+                BorderThickness="1"
+                CornerRadius="3">
+            <ScrollViewer>
+                <StackPanel>
+                    <!-- Header Row -->
+                    <Border BorderBrush="LightGray"
+                            BorderThickness="0,0,0,1"
+                            Background="#F5F5F5"
+                            Padding="8,6">
+                        <Grid ColumnDefinitions="70,90,90,90,90,60">
+                            <TextBlock Grid.Column="0" Text="Note #" FontWeight="Bold" FontSize="12"/>
+                            <TextBlock Grid.Column="1" Text="Left Paddle" FontWeight="Bold" FontSize="12"/>
+                            <TextBlock Grid.Column="2" Text="Right Paddle" FontWeight="Bold" FontSize="12"/>
+                            <TextBlock Grid.Column="3" Text="Straight Key" FontWeight="Bold" FontSize="12"/>
+                            <TextBlock Grid.Column="4" Text="PTT" FontWeight="Bold" FontSize="12"/>
+                            <TextBlock Grid.Column="5" Text="Remove" FontWeight="Bold" FontSize="12"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Data Rows -->
+                    <ItemsControl ItemsSource="{Binding NoteConfigurations}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="vm:MidiNoteConfigRow">
+                                <Border BorderBrush="LightGray"
+                                        BorderThickness="0,0,0,1"
+                                        Padding="8,6">
+                                    <Grid ColumnDefinitions="70,90,90,90,90,60">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding NoteNumber}"
+                                                   VerticalAlignment="Center"
+                                                   FontFamily="Consolas,Courier New,monospace"/>
+                                        <CheckBox Grid.Column="1"
+                                                  IsChecked="{Binding IsLeftPaddle}"
+                                                  HorizontalAlignment="Center"/>
+                                        <CheckBox Grid.Column="2"
+                                                  IsChecked="{Binding IsRightPaddle}"
+                                                  HorizontalAlignment="Center"/>
+                                        <CheckBox Grid.Column="3"
+                                                  IsChecked="{Binding IsStraightKey}"
+                                                  HorizontalAlignment="Center"/>
+                                        <CheckBox Grid.Column="4"
+                                                  IsChecked="{Binding IsPtt}"
+                                                  HorizontalAlignment="Center"/>
+                                        <Button Grid.Column="5"
+                                                Content="×"
+                                                Command="{Binding $parent[Window].DataContext.RemoveNoteCommand}"
+                                                CommandParameter="{Binding}"
+                                                FontSize="16"
+                                                Width="30"
+                                                Height="25"
+                                                Padding="0"
+                                                HorizontalAlignment="Center"
+                                                HorizontalContentAlignment="Center"
+                                                VerticalContentAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Function Descriptions -->
+        <Border Grid.Row="3"
+                BorderBrush="LightGray"
+                BorderThickness="1"
+                Background="#FAFAFA"
+                Padding="10"
+                CornerRadius="3"
+                Margin="0,10,0,0">
+            <StackPanel Spacing="4">
+                <TextBlock FontWeight="SemiBold" FontSize="11" Margin="0,0,0,3">Function Descriptions:</TextBlock>
+                <TextBlock FontSize="10" Foreground="#444">• Left Paddle: Used as dit paddle in iambic mode</TextBlock>
+                <TextBlock FontSize="10" Foreground="#444">• Right Paddle: Used as dah paddle in iambic mode</TextBlock>
+                <TextBlock FontSize="10" Foreground="#444">• Straight Key: Key down/up in straight key mode</TextBlock>
+                <TextBlock FontSize="10" Foreground="#444">• PTT: Push-to-talk for non-CW modes (not yet implemented)</TextBlock>
+            </StackPanel>
+        </Border>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="4"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="10"
+                    Margin="0,15,0,0">
+            <Button Content="Reset to Defaults"
+                    Command="{Binding ResetToDefaultsCommand}"
+                    Width="130"
+                    Padding="6"/>
+            <Button Name="CancelButton"
+                    Content="Cancel"
+                    Width="80"
+                    Padding="6"
+                    Click="CancelButton_Click"/>
+            <Button Name="OkButton"
+                    Content="OK"
+                    Width="80"
+                    Padding="6"
+                    Click="OkButton_Click"
+                    IsDefault="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/MidiConfigDialog.axaml.cs
+++ b/Views/MidiConfigDialog.axaml.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using NetKeyer.Models;
+using NetKeyer.ViewModels;
+
+namespace NetKeyer.Views
+{
+    public partial class MidiConfigDialog : Window
+    {
+        private MidiConfigDialogViewModel _viewModel;
+
+        public bool ConfigurationSaved { get; private set; }
+        public List<MidiNoteMapping> Mappings { get; private set; }
+
+        public MidiConfigDialog()
+        {
+            InitializeComponent();
+            _viewModel = new MidiConfigDialogViewModel();
+            DataContext = _viewModel;
+        }
+
+        public void LoadMappings(List<MidiNoteMapping> mappings)
+        {
+            _viewModel.LoadMappings(mappings);
+        }
+
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            Mappings = _viewModel.GetMappings();
+            ConfigurationSaved = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            ConfigurationSaved = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
Allow the user to define the roles of MIDI notes (CW iambic left/right paddle, CW straight key, PTT) and save them in config. Defaults are provided that should work reasonably with either HaliKey MIDI or CTR2-MIDI.