### PR TITLE
Add a workaround to let alsa-sharp find ALSA without -dev packages

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -18,6 +18,8 @@
 // ------------------------------------------------------------
 using Avalonia;
 using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Velopack;
 
 namespace NetKeyer;
@@ -30,6 +32,9 @@ sealed class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // Configure native library loading for ALSA on Linux before any libraries are loaded
+        ConfigureNativeLibraries();
+
         // Velopack: Handle app installation/update events before starting the main app
         VelopackApp.Build().Run();
 
@@ -42,4 +47,47 @@ sealed class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+    /// <summary>
+    /// Configures native library loading for cross-platform compatibility.
+    /// On Linux, this sets up a resolver to redirect ALSA library loading from
+    /// "libasound.so" (dev package) to "libasound.so.2" (runtime package).
+    /// </summary>
+    private static void ConfigureNativeLibraries()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            // Set up resolver for alsa-sharp's ALSA library dependency.
+            // The alsa-sharp library (used by managed-midi) uses [DllImport("asound")] which
+            // looks for "libasound.so", but this symlink is only present in the ALSA development
+            // package (libasound2-dev). On runtime-only systems, we need to load "libasound.so.2" instead.
+            AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>
+            {
+                if (args.LoadedAssembly.GetName().Name == "alsa-sharp")
+                {
+                    NativeLibrary.SetDllImportResolver(args.LoadedAssembly, AlsaLibraryResolver);
+                }
+            };
+        }
+    }
+
+    /// <summary>
+    /// Custom native library resolver for ALSA on Linux.
+    /// Redirects "asound" to "libasound.so.2" (runtime library) instead of
+    /// "libasound.so" (dev package symlink).
+    /// </summary>
+    private static IntPtr AlsaLibraryResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (libraryName == "asound")
+        {
+            // Try to load the runtime version of the ALSA library
+            if (NativeLibrary.TryLoad("libasound.so.2", assembly, searchPath, out var handle))
+            {
+                return handle;
+            }
+        }
+
+        // Return IntPtr.Zero to let the default loading mechanism try
+        return IntPtr.Zero;
+    }
 }


### PR DESCRIPTION
alsa-sharp does a `[DllImport("asound")]` which looks for libasound.so. If the user has libasound2-dev (or the equivalent on their system) that succeeds, but if they only have the runtime libs, it fails, leading to no MIDI devices being available (an exception is thrown, but caught and merely logs an uninformative error to the console).

We can fix this by doing class-loader voodoo to hook alsa-sharp's DLL resolver, and tell it to attempt loading "libasound.so.2" (the correct runtime name) when alsa-sharp requests "asound".

Fixes #44.