### PR TITLE
Use computed timing for iambic keyer

### DIFF
--- a/Keying/IambicKeyer.cs
+++ b/Keying/IambicKeyer.cs
@@ -70,6 +70,7 @@ public class IambicKeyer
         _sidetoneGenerator.OnToneStart += OnToneStart;
         _sidetoneGenerator.OnToneComplete += OnToneComplete;
         _sidetoneGenerator.OnBeforeSilenceEnd += OnBeforeSilenceEnd;
+        DebugLogger.Log("keyer", $"[IambicKeyer] Constructor: Subscribed to sidetone generator events (generator={_sidetoneGenerator.GetHashCode()})");
     }
 
     /// <summary>
@@ -201,6 +202,25 @@ public class IambicKeyer
     }
 
     /// <summary>
+    /// Disposes the keyer and unsubscribes from sidetone generator events.
+    /// </summary>
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_sidetoneGenerator != null)
+            {
+                _sidetoneGenerator.OnSilenceComplete -= OnSilenceComplete;
+                _sidetoneGenerator.OnToneStart -= OnToneStart;
+                _sidetoneGenerator.OnToneComplete -= OnToneComplete;
+                _sidetoneGenerator.OnBeforeSilenceEnd -= OnBeforeSilenceEnd;
+                DebugLogger.Log("keyer", $"[IambicKeyer] Disposed and unsubscribed from generator ({_sidetoneGenerator.GetHashCode()})");
+                _sidetoneGenerator = null;
+            }
+        }
+    }
+
+    /// <summary>
     /// Updates the sidetone generator. Useful when changing audio output device.
     /// </summary>
     public void UpdateSidetoneGenerator(ISidetoneGenerator sidetoneGenerator)
@@ -210,6 +230,12 @@ public class IambicKeyer
             if (sidetoneGenerator == null)
                 throw new ArgumentNullException(nameof(sidetoneGenerator));
 
+            int oldHash = _sidetoneGenerator?.GetHashCode() ?? 0;
+            int newHash = sidetoneGenerator.GetHashCode();
+            bool isSameInstance = (_sidetoneGenerator == sidetoneGenerator);
+
+            DebugLogger.Log("keyer", $"[IambicKeyer] UpdateSidetoneGenerator called: oldGen={oldHash}, newGen={newHash}, sameInstance={isSameInstance}");
+
             // Unsubscribe from old generator events
             if (_sidetoneGenerator != null)
             {
@@ -217,6 +243,7 @@ public class IambicKeyer
                 _sidetoneGenerator.OnToneStart -= OnToneStart;
                 _sidetoneGenerator.OnToneComplete -= OnToneComplete;
                 _sidetoneGenerator.OnBeforeSilenceEnd -= OnBeforeSilenceEnd;
+                DebugLogger.Log("keyer", $"[IambicKeyer] Unsubscribed from old generator ({oldHash})");
             }
 
             // Update to new generator
@@ -228,7 +255,7 @@ public class IambicKeyer
             _sidetoneGenerator.OnToneComplete += OnToneComplete;
             _sidetoneGenerator.OnBeforeSilenceEnd += OnBeforeSilenceEnd;
 
-            DebugLogger.Log("keyer", $"[IambicKeyer] Sidetone generator updated");
+            DebugLogger.Log("keyer", $"[IambicKeyer] Subscribed to new generator ({newHash})");
         }
     }
 

--- a/Services/KeyingController.cs
+++ b/Services/KeyingController.cs
@@ -193,4 +193,10 @@ public class KeyingController
         _previousStraightKeyState = false;
         _previousPttState = false;
     }
+
+    public void Dispose()
+    {
+        _iambicKeyer?.Dispose();
+        _iambicKeyer = null;
+    }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1069,6 +1069,8 @@ public partial class MainWindowViewModel : ViewModelBase
             ConnectButtonText = "Disconnect";
 
             // Reinitialize keying controller with the correct radio client handle
+            // First dispose the old controller to unsubscribe from events
+            _keyingController?.Dispose();
             _keyingController = new KeyingController(_sidetoneGenerator);
             _keyingController.Initialize(
                 _boundGuiClientHandle,


### PR DESCRIPTION
This should improve the accuracy of the keying (what the radio actually transmits) in general, especially if the system running NetKeyer is slower or the audio device is laggy, and it should reduce the occurrence of "runt dits" or missing dits at the beginning of a sequence.