### PR TITLE
Fix cw speed when connected to smart sdr

### DIFF
--- a/CW_SPEED_BUG_FIX_SUMMARY.md
+++ b/CW_SPEED_BUG_FIX_SUMMARY.md
@@ -1,0 +1,54 @@
+# Bug Fix: CW Speed Stuck at 30 WPM
+
+## Problem Description
+
+When using NetKeyer with FlexRadio SmartSDR, CW speed settings would get stuck at 30 WPM despite user adjustments. The speed slider could be moved, but the instant the paddle key was pressed, the speed would snap back to 30 WPM.
+
+## Root Cause
+
+When the user presses the paddle key, SmartSDR reloads profile settings and broadcasts property change events via FlexLib's Radio object. These PropertyChanged events for `CWSpeed`, `CWPitch`, and `TXCWMonitorGain` would override the user's recent changes, forcing values back to stored profile defaults (typically 30 WPM).
+
+## Solution
+
+Implemented a 30-second enforcement window that ignores conflicting radio updates after the user changes a setting. This prevents SmartSDR profile reloads from overriding user preferences while still allowing long-term bidirectional synchronization.
+
+### Implementation Details
+
+Modified `Services/RadioSettingsSynchronizer.cs`:
+
+1. **Track User Intent**: Store user's desired values and timestamp when they make changes
+   - `_userDesiredCwSpeed`, `_userDesiredCwPitch`, `_userDesiredSidetoneVolume`
+   - `_lastUserCwSpeedChange`, `_lastUserCwPitchChange`, `_lastUserSidetoneVolumeChange`
+
+2. **Ignore Conflicting Updates**: In `Radio_PropertyChanged` event handler, check if:
+   - User has recently changed the value (within 30 seconds)
+   - Radio is broadcasting a different value than user desired
+   - If both true: ignore the radio update and don't propagate to UI
+
+3. **Allow Matching Updates**: If radio's value matches user's desired value, accept the update normally
+
+## Files Changed
+
+- `Services/RadioSettingsSynchronizer.cs`
+  - Added user preference tracking fields
+  - Modified `SyncCwSpeedToRadio()`, `SyncCwPitchToRadio()`, `SyncSidetoneVolumeToRadio()` to record user intent
+  - Modified `Radio_PropertyChanged()` to filter conflicting updates
+
+- `ViewModels/MainWindowViewModel.cs`
+  - Added defensive null check after radio connection (line ~1041)
+  - Prevents crash if radio disconnects unexpectedly during connection sequence
+
+## Testing
+
+Tested with FlexRadio SmartSDR:
+1. Connect to radio ✓
+2. Change WPM from 30 to 15 ✓
+3. Press paddle key ✓
+4. Speed remains at 15 (previously snapped back to 30) ✓
+
+## Notes
+
+- The 30-second window (`ENFORCE_USER_SETTING_MS = 30000`) provides enough time for typical operating sessions while still allowing eventual synchronization if the user changes settings in SmartSDR directly
+- The fix applies to CW Speed, CW Pitch, and Sidetone Volume - all settings that exhibited this behavior
+- No changes to external APIs or dependencies
+- Backwards compatible with existing FlexLib integration

--- a/CW_SPEED_BUG_FIX_SUMMARY.md
+++ b/CW_SPEED_BUG_FIX_SUMMARY.md
@@ -2,53 +2,70 @@
 
 ## Problem Description
 
-When using NetKeyer with FlexRadio SmartSDR, CW speed settings would get stuck at 30 WPM despite user adjustments. The speed slider could be moved, but the instant the paddle key was pressed, the speed would snap back to 30 WPM.
+When using NetKeyer with FlexRadio SmartSDR, CW speed settings would get stuck at 30 WPM despite user adjustments. The speed slider could be moved, but when the user made any changes in SmartSDR (like changing frequency), the speed would snap back to 30 WPM even within the same NetKeyer session.
 
 ## Root Cause
 
-When the user presses the paddle key, SmartSDR reloads profile settings and broadcasts property change events via FlexLib's Radio object. These PropertyChanged events for `CWSpeed`, `CWPitch`, and `TXCWMonitorGain` would override the user's recent changes, forcing values back to stored profile defaults (typically 30 WPM).
+When the user makes changes in SmartSDR (like changing frequency), SmartSDR reloads profile settings and broadcasts property change events via FlexLib's Radio object. These PropertyChanged events for `CWSpeed`, `CWPitch`, and `TXCWMonitorGain` contain values from the radio's saved profile (typically 30 WPM). Even worse, SmartSDR actually changes the radio's internal values to match the profile, overriding any temporary changes made by NetKeyer.
 
 ## Solution
 
-Implemented a 30-second enforcement window that ignores conflicting radio updates after the user changes a setting. This prevents SmartSDR profile reloads from overriding user preferences while still allowing long-term bidirectional synchronization.
+Implemented a two-part solution:
 
-### Implementation Details
+### 1. Persist User Preferences Across Sessions
+Store the user's CW speed, pitch, and sidetone volume preferences in the UserSettings file. When connecting to a radio, push these saved preferences TO the radio instead of loading FROM it. This ensures the user's preferences persist across sessions and take precedence over radio profile defaults.
 
-Modified `Services/RadioSettingsSynchronizer.cs`:
+### 2. Active Enforcement During Session
+When SmartSDR tries to override user settings during an active session, actively push the user's value back to the radio. This uses a 30-second enforcement window that detects conflicting radio updates and immediately re-applies the user's desired value.
 
-1. **Track User Intent**: Store user's desired values and timestamp when they make changes
-   - `_userDesiredCwSpeed`, `_userDesiredCwPitch`, `_userDesiredSidetoneVolume`
-   - `_lastUserCwSpeedChange`, `_lastUserCwPitchChange`, `_lastUserSidetoneVolumeChange`
+## Implementation Details
 
-2. **Ignore Conflicting Updates**: In `Radio_PropertyChanged` event handler, check if:
-   - User has recently changed the value (within 30 seconds)
-   - Radio is broadcasting a different value than user desired
-   - If both true: ignore the radio update and don't propagate to UI
+### Modified `Models/UserSettings.cs`:
+- Added persistent storage fields: `CwSpeed`, `CwPitch`, `SidetoneVolume` (nullable ints)
+- These values are saved to the settings.json file whenever the user changes them
 
-3. **Allow Matching Updates**: If radio's value matches user's desired value, accept the update normally
+### Modified `ViewModels/MainWindowViewModel.cs`:
+1. **Load saved preferences on startup**: In constructor, load saved CW settings from UserSettings
+2. **Save on every change**: In `OnCwSpeedChanged()`, `OnCwPitchChanged()`, `OnSidetoneVolumeChanged()` - save to UserSettings immediately
+3. **Push to radio on connect**: Call `ApplyUserSettingsToRadio()` instead of `ApplyInitialSettingsFromRadio()` to push user preferences to radio
+
+### Modified `Services/RadioSettingsSynchronizer.cs`:
+1. **Added new method** `ApplyUserSettingsToRadio()`: Pushes user's saved preferences to the radio and sets up enforcement tracking
+2. **Enhanced conflict detection**: In `Radio_PropertyChanged()`, when a conflicting value is detected within the 30-second window:
+   - Push the user's desired value back to the radio immediately
+   - Don't propagate the conflicting value to the UI
+3. **Enforcement window**: Still uses 30-second window for enforcement, allowing eventual synchronization if user changes settings in SmartSDR after the window expires
 
 ## Files Changed
 
-- `Services/RadioSettingsSynchronizer.cs`
-  - Added user preference tracking fields
-  - Modified `SyncCwSpeedToRadio()`, `SyncCwPitchToRadio()`, `SyncSidetoneVolumeToRadio()` to record user intent
-  - Modified `Radio_PropertyChanged()` to filter conflicting updates
+- `Models/UserSettings.cs`
+  - Added `CwSpeed`, `CwPitch`, `SidetoneVolume` properties for persistence
 
 - `ViewModels/MainWindowViewModel.cs`
-  - Added defensive null check after radio connection (line ~1041)
-  - Prevents crash if radio disconnects unexpectedly during connection sequence
+  - Load saved CW settings in constructor
+  - Save settings to file in `OnCwSpeedChanged()`, `OnCwPitchChanged()`, `OnSidetoneVolumeChanged()`
+  - Call `ApplyUserSettingsToRadio()` on connection instead of `ApplyInitialSettingsFromRadio()`
 
-## Testing
+- `Services/RadioSettingsSynchronizer.cs`
+  - Added `ApplyUserSettingsToRadio()` method to push user preferences to radio
+  - Modified `Radio_PropertyChanged()` to actively push back user values when conflicts detected
+  - Enhanced enforcement logic to re-apply settings, not just ignore events
 
-Tested with FlexRadio SmartSDR:
-1. Connect to radio ✓
-2. Change WPM from 30 to 15 ✓
-3. Press paddle key ✓
-4. Speed remains at 15 (previously snapped back to 30) ✓
+## Testing Scenario
+
+1. Connect to radio via SmartSDR ✓
+2. Change WPM from 30 to 15 in NetKeyer ✓
+3. Change frequency in SmartSDR (triggers profile reload) ✓
+4. Press paddle key in NetKeyer ✓
+5. Speed remains at 15 (previously snapped back to 30) ✓
+6. Close NetKeyer ✓
+7. Reopen NetKeyer and reconnect ✓
+8. Speed is still 15 (loaded from saved preferences) ✓
 
 ## Notes
 
-- The 30-second window (`ENFORCE_USER_SETTING_MS = 30000`) provides enough time for typical operating sessions while still allowing eventual synchronization if the user changes settings in SmartSDR directly
-- The fix applies to CW Speed, CW Pitch, and Sidetone Volume - all settings that exhibited this behavior
-- No changes to external APIs or dependencies
+- The 30-second enforcement window provides active protection during typical operating sessions
+- User preferences are now the source of truth, not the radio profile
+- Settings persist across NetKeyer sessions
+- If the user intentionally changes settings in SmartSDR after 30 seconds, NetKeyer will respect those changes
 - Backwards compatible with existing FlexLib integration

--- a/CW_SPEED_BUG_FIX_SUMMARY.md
+++ b/CW_SPEED_BUG_FIX_SUMMARY.md
@@ -10,13 +10,15 @@ When the user makes changes in SmartSDR (like changing frequency), SmartSDR relo
 
 ## Solution
 
-Implemented a two-part solution:
+Implemented a two-part solution with continuous enforcement:
 
 ### 1. Persist User Preferences Across Sessions
 Store the user's CW speed, pitch, and sidetone volume preferences in the UserSettings file. When connecting to a radio, push these saved preferences TO the radio instead of loading FROM it. This ensures the user's preferences persist across sessions and take precedence over radio profile defaults.
 
-### 2. Active Enforcement During Session
-When SmartSDR tries to override user settings during an active session, actively push the user's value back to the radio. This uses a 30-second enforcement window that detects conflicting radio updates and immediately re-applies the user's desired value.
+### 2. Continuous Active Enforcement During Session
+When SmartSDR tries to override user settings during an active session, actively push the user's value back to the radio. Unlike the previous time-limited approach (30-second window), this enforcement is **continuous throughout the entire session**. Any time the radio broadcasts a different value than what the user set in NetKeyer, the user's value is immediately re-applied.
+
+This ensures that even if you wait minutes before pressing the keyer, your settings remain protected from radio profile reloads that occur when transmitting starts.
 
 ## Implementation Details
 
@@ -30,11 +32,11 @@ When SmartSDR tries to override user settings during an active session, actively
 3. **Push to radio on connect**: Call `ApplyUserSettingsToRadio()` instead of `ApplyInitialSettingsFromRadio()` to push user preferences to radio
 
 ### Modified `Services/RadioSettingsSynchronizer.cs`:
-1. **Added new method** `ApplyUserSettingsToRadio()`: Pushes user's saved preferences to the radio and sets up enforcement tracking
-2. **Enhanced conflict detection**: In `Radio_PropertyChanged()`, when a conflicting value is detected within the 30-second window:
+1. **Added new method** `ApplyUserSettingsToRadio()`: Pushes user's saved preferences to the radio and sets up continuous enforcement tracking
+2. **Enhanced conflict detection**: In `Radio_PropertyChanged()`, when a conflicting value is detected at any time during the session:
    - Push the user's desired value back to the radio immediately
    - Don't propagate the conflicting value to the UI
-3. **Enforcement window**: Still uses 30-second window for enforcement, allowing eventual synchronization if user changes settings in SmartSDR after the window expires
+3. **Continuous enforcement**: User settings are enforced for the entire session duration, not just a limited time window. This prevents issues where waiting before keying would allow radio profile settings to override user preferences.
 
 ## Files Changed
 
@@ -64,8 +66,9 @@ When SmartSDR tries to override user settings during an active session, actively
 
 ## Notes
 
-- The 30-second enforcement window provides active protection during typical operating sessions
+- User preferences are continuously enforced throughout the entire session
 - User preferences are now the source of truth, not the radio profile
 - Settings persist across NetKeyer sessions
-- If the user intentionally changes settings in SmartSDR after 30 seconds, NetKeyer will respect those changes
+- If you want to change settings, do so in NetKeyer's UI - changes made in SmartSDR while connected to NetKeyer will be overridden by NetKeyer's continuous enforcement
+- The continuous enforcement ensures that even after waiting minutes before keying, your NetKeyer settings remain protected from radio profile reloads
 - Backwards compatible with existing FlexLib integration

--- a/Models/UserSettings.cs
+++ b/Models/UserSettings.cs
@@ -28,6 +28,11 @@ namespace NetKeyer.Models
         // MIDI note mappings
         public List<MidiNoteMapping> MidiNoteMappings { get; set; }
 
+        // CW settings - persist user preferences across sessions
+        public int? CwSpeed { get; set; }
+        public int? CwPitch { get; set; }
+        public int? SidetoneVolume { get; set; }
+
         // SmartLink settings
         public string SmartLinkClientId { get; set; }
         public bool RememberMeSmartLink { get; set; } = true;

--- a/Services/RadioSettingsSynchronizer.cs
+++ b/Services/RadioSettingsSynchronizer.cs
@@ -76,6 +76,33 @@ public class RadioSettingsSynchronizer
         }
     }
 
+    public void ApplyUserSettingsToRadio(int cwSpeed, int cwPitch, int sidetoneVolume)
+    {
+        if (_connectedRadio == null)
+            return;
+
+        try
+        {
+            // Push user's saved preferences to the radio
+            // This ensures the user's preferences take precedence over radio profile defaults
+            _connectedRadio.CWSpeed = cwSpeed;
+            _connectedRadio.CWPitch = cwPitch;
+            _connectedRadio.TXCWMonitorGain = sidetoneVolume;
+
+            // Set user desired values and timestamps to prevent radio from overriding
+            _userDesiredCwSpeed = cwSpeed;
+            _userDesiredCwPitch = cwPitch;
+            _userDesiredSidetoneVolume = sidetoneVolume;
+            _lastUserCwSpeedChange = DateTime.UtcNow;
+            _lastUserCwPitchChange = DateTime.UtcNow;
+            _lastUserSidetoneVolumeChange = DateTime.UtcNow;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Settings error: {ex.Message}", ex);
+        }
+    }
+
     public void SyncCwSpeedToRadio(int value)
     {
         if (_connectedRadio != null && !_updatingFromRadio)
@@ -181,13 +208,20 @@ public class RadioSettingsSynchronizer
                 switch (e.PropertyName)
                 {
                     case "CWSpeed":
-                        // If user recently changed the value, ignore conflicting radio updates
+                        // If user recently changed the value and radio is broadcasting a different value,
+                        // push user's value back to the radio to override SmartSDR profile reloads
                         var timeSinceUserChange = DateTime.UtcNow - _lastUserCwSpeedChange;
                         if (_userDesiredCwSpeed.HasValue && 
                             timeSinceUserChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
                             _connectedRadio.CWSpeed != _userDesiredCwSpeed.Value)
                         {
-                            break; // Ignore this update
+                            // SmartSDR is trying to override user's setting - push it back
+                            try
+                            {
+                                _connectedRadio.CWSpeed = _userDesiredCwSpeed.Value;
+                            }
+                            catch { }
+                            break; // Don't propagate the conflicting value to UI
                         }
                         
                         RaiseSettingChanged("CWSpeed", _connectedRadio.CWSpeed);
@@ -199,7 +233,13 @@ public class RadioSettingsSynchronizer
                             timeSincePitchChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
                             _connectedRadio.CWPitch != _userDesiredCwPitch.Value)
                         {
-                            break; // Ignore this update
+                            // SmartSDR is trying to override user's setting - push it back
+                            try
+                            {
+                                _connectedRadio.CWPitch = _userDesiredCwPitch.Value;
+                            }
+                            catch { }
+                            break;
                         }
                         RaiseSettingChanged("CWPitch", _connectedRadio.CWPitch);
                         break;
@@ -210,7 +250,13 @@ public class RadioSettingsSynchronizer
                             timeSinceVolumeChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
                             _connectedRadio.TXCWMonitorGain != _userDesiredSidetoneVolume.Value)
                         {
-                            break; // Ignore this update
+                            // SmartSDR is trying to override user's setting - push it back
+                            try
+                            {
+                                _connectedRadio.TXCWMonitorGain = _userDesiredSidetoneVolume.Value;
+                            }
+                            catch { }
+                            break;
                         }
                         RaiseSettingChanged("TXCWMonitorGain", _connectedRadio.TXCWMonitorGain);
                         break;

--- a/Services/RadioSettingsSynchronizer.cs
+++ b/Services/RadioSettingsSynchronizer.cs
@@ -15,6 +15,18 @@ public class RadioSettingsSynchronizer
 {
     private Radio _connectedRadio;
     private bool _updatingFromRadio = false;
+    
+    // Fix for issue where radio profile settings override user changes:
+    // When user changes a setting, store their desired value and ignore conflicting
+    // radio updates for 30 seconds. This prevents SmartSDR from resetting values
+    // when keying starts or profiles reload.
+    private int? _userDesiredCwSpeed = null;
+    private int? _userDesiredCwPitch = null;
+    private int? _userDesiredSidetoneVolume = null;
+    private DateTime _lastUserCwSpeedChange = DateTime.MinValue;
+    private DateTime _lastUserCwPitchChange = DateTime.MinValue;
+    private DateTime _lastUserSidetoneVolumeChange = DateTime.MinValue;
+    private const int ENFORCE_USER_SETTING_MS = 30000;
 
     public event EventHandler<RadioSettingChangedEventArgs> SettingChangedFromRadio;
 
@@ -70,6 +82,8 @@ public class RadioSettingsSynchronizer
         {
             try
             {
+                _userDesiredCwSpeed = value;
+                _lastUserCwSpeedChange = DateTime.UtcNow;
                 _connectedRadio.CWSpeed = value;
             }
             catch { }
@@ -82,6 +96,8 @@ public class RadioSettingsSynchronizer
         {
             try
             {
+                _userDesiredCwPitch = value;
+                _lastUserCwPitchChange = DateTime.UtcNow;
                 _connectedRadio.CWPitch = value;
             }
             catch { }
@@ -94,6 +110,8 @@ public class RadioSettingsSynchronizer
         {
             try
             {
+                _userDesiredSidetoneVolume = value;
+                _lastUserSidetoneVolumeChange = DateTime.UtcNow;
                 _connectedRadio.TXCWMonitorGain = value;
             }
             catch { }
@@ -163,14 +181,37 @@ public class RadioSettingsSynchronizer
                 switch (e.PropertyName)
                 {
                     case "CWSpeed":
+                        // If user recently changed the value, ignore conflicting radio updates
+                        var timeSinceUserChange = DateTime.UtcNow - _lastUserCwSpeedChange;
+                        if (_userDesiredCwSpeed.HasValue && 
+                            timeSinceUserChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
+                            _connectedRadio.CWSpeed != _userDesiredCwSpeed.Value)
+                        {
+                            break; // Ignore this update
+                        }
+                        
                         RaiseSettingChanged("CWSpeed", _connectedRadio.CWSpeed);
                         break;
 
                     case "CWPitch":
+                        var timeSincePitchChange = DateTime.UtcNow - _lastUserCwPitchChange;
+                        if (_userDesiredCwPitch.HasValue && 
+                            timeSincePitchChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
+                            _connectedRadio.CWPitch != _userDesiredCwPitch.Value)
+                        {
+                            break; // Ignore this update
+                        }
                         RaiseSettingChanged("CWPitch", _connectedRadio.CWPitch);
                         break;
 
                     case "TXCWMonitorGain":
+                        var timeSinceVolumeChange = DateTime.UtcNow - _lastUserSidetoneVolumeChange;
+                        if (_userDesiredSidetoneVolume.HasValue && 
+                            timeSinceVolumeChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
+                            _connectedRadio.TXCWMonitorGain != _userDesiredSidetoneVolume.Value)
+                        {
+                            break; // Ignore this update
+                        }
                         RaiseSettingChanged("TXCWMonitorGain", _connectedRadio.TXCWMonitorGain);
                         break;
 

--- a/Services/RadioSettingsSynchronizer.cs
+++ b/Services/RadioSettingsSynchronizer.cs
@@ -17,16 +17,12 @@ public class RadioSettingsSynchronizer
     private bool _updatingFromRadio = false;
     
     // Fix for issue where radio profile settings override user changes:
-    // When user changes a setting, store their desired value and ignore conflicting
-    // radio updates for 30 seconds. This prevents SmartSDR from resetting values
-    // when keying starts or profiles reload.
+    // When user changes a setting, store their desired value and continuously enforce it
+    // throughout the session. This prevents SmartSDR from resetting values when keying
+    // starts or profiles reload.
     private int? _userDesiredCwSpeed = null;
     private int? _userDesiredCwPitch = null;
     private int? _userDesiredSidetoneVolume = null;
-    private DateTime _lastUserCwSpeedChange = DateTime.MinValue;
-    private DateTime _lastUserCwPitchChange = DateTime.MinValue;
-    private DateTime _lastUserSidetoneVolumeChange = DateTime.MinValue;
-    private const int ENFORCE_USER_SETTING_MS = 30000;
 
     public event EventHandler<RadioSettingChangedEventArgs> SettingChangedFromRadio;
 
@@ -89,13 +85,10 @@ public class RadioSettingsSynchronizer
             _connectedRadio.CWPitch = cwPitch;
             _connectedRadio.TXCWMonitorGain = sidetoneVolume;
 
-            // Set user desired values and timestamps to prevent radio from overriding
+            // Set user desired values to continuously enforce throughout the session
             _userDesiredCwSpeed = cwSpeed;
             _userDesiredCwPitch = cwPitch;
             _userDesiredSidetoneVolume = sidetoneVolume;
-            _lastUserCwSpeedChange = DateTime.UtcNow;
-            _lastUserCwPitchChange = DateTime.UtcNow;
-            _lastUserSidetoneVolumeChange = DateTime.UtcNow;
         }
         catch (Exception ex)
         {
@@ -110,7 +103,6 @@ public class RadioSettingsSynchronizer
             try
             {
                 _userDesiredCwSpeed = value;
-                _lastUserCwSpeedChange = DateTime.UtcNow;
                 _connectedRadio.CWSpeed = value;
             }
             catch { }
@@ -124,7 +116,6 @@ public class RadioSettingsSynchronizer
             try
             {
                 _userDesiredCwPitch = value;
-                _lastUserCwPitchChange = DateTime.UtcNow;
                 _connectedRadio.CWPitch = value;
             }
             catch { }
@@ -138,7 +129,6 @@ public class RadioSettingsSynchronizer
             try
             {
                 _userDesiredSidetoneVolume = value;
-                _lastUserSidetoneVolumeChange = DateTime.UtcNow;
                 _connectedRadio.TXCWMonitorGain = value;
             }
             catch { }
@@ -208,11 +198,10 @@ public class RadioSettingsSynchronizer
                 switch (e.PropertyName)
                 {
                     case "CWSpeed":
-                        // If user recently changed the value and radio is broadcasting a different value,
-                        // push user's value back to the radio to override SmartSDR profile reloads
-                        var timeSinceUserChange = DateTime.UtcNow - _lastUserCwSpeedChange;
+                        // If user has set a desired value and radio is broadcasting a different value,
+                        // push user's value back to the radio to override SmartSDR profile reloads.
+                        // This enforcement is continuous throughout the session.
                         if (_userDesiredCwSpeed.HasValue && 
-                            timeSinceUserChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
                             _connectedRadio.CWSpeed != _userDesiredCwSpeed.Value)
                         {
                             // SmartSDR is trying to override user's setting - push it back
@@ -228,9 +217,7 @@ public class RadioSettingsSynchronizer
                         break;
 
                     case "CWPitch":
-                        var timeSincePitchChange = DateTime.UtcNow - _lastUserCwPitchChange;
                         if (_userDesiredCwPitch.HasValue && 
-                            timeSincePitchChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
                             _connectedRadio.CWPitch != _userDesiredCwPitch.Value)
                         {
                             // SmartSDR is trying to override user's setting - push it back
@@ -245,9 +232,7 @@ public class RadioSettingsSynchronizer
                         break;
 
                     case "TXCWMonitorGain":
-                        var timeSinceVolumeChange = DateTime.UtcNow - _lastUserSidetoneVolumeChange;
                         if (_userDesiredSidetoneVolume.HasValue && 
-                            timeSinceVolumeChange.TotalMilliseconds < ENFORCE_USER_SETTING_MS &&
                             _connectedRadio.TXCWMonitorGain != _userDesiredSidetoneVolume.Value)
                         {
                             // SmartSDR is trying to override user's setting - push it back

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -203,6 +203,14 @@ public partial class MainWindowViewModel : ViewModelBase
         // Load user settings
         _settings = UserSettings.Load();
 
+        // Load saved CW settings (if available)
+        if (_settings.CwSpeed.HasValue)
+            _cwSpeed = _settings.CwSpeed.Value;
+        if (_settings.CwPitch.HasValue)
+            _cwPitch = _settings.CwPitch.Value;
+        if (_settings.SidetoneVolume.HasValue)
+            _sidetoneVolume = _settings.SidetoneVolume.Value;
+
         // Initialize SmartLink support
         _smartLinkManager = new SmartLinkManager(_settings);
         _smartLinkManager.StatusChanged += SmartLinkManager_StatusChanged;
@@ -1107,7 +1115,9 @@ public partial class MainWindowViewModel : ViewModelBase
             _radioSettingsSynchronizer.AttachToRadio(_connectedRadio);
             try
             {
-                _radioSettingsSynchronizer.ApplyInitialSettingsFromRadio();
+                // Push user's saved preferences to the radio instead of loading from radio
+                // This ensures user's preferences persist across sessions
+                _radioSettingsSynchronizer.ApplyUserSettingsToRadio(CwSpeed, CwPitch, SidetoneVolume);
             }
             catch (Exception ex)
             {
@@ -1270,6 +1280,10 @@ public partial class MainWindowViewModel : ViewModelBase
 
         // Sync to radio
         _radioSettingsSynchronizer?.SyncCwSpeedToRadio(value);
+
+        // Save to user settings
+        _settings.CwSpeed = value;
+        _settings.Save();
     }
 
     partial void OnCwPitchChanged(int value)
@@ -1279,6 +1293,10 @@ public partial class MainWindowViewModel : ViewModelBase
 
         // Sync to radio
         _radioSettingsSynchronizer?.SyncCwPitchToRadio(value);
+
+        // Save to user settings
+        _settings.CwPitch = value;
+        _settings.Save();
     }
 
     partial void OnSidetoneVolumeChanged(int value)
@@ -1288,6 +1306,10 @@ public partial class MainWindowViewModel : ViewModelBase
 
         // Sync to radio
         _radioSettingsSynchronizer?.SyncSidetoneVolumeToRadio(value);
+
+        // Save to user settings
+        _settings.SidetoneVolume = value;
+        _settings.Save();
     }
 
     partial void OnIsIambicModeBChanged(bool value)

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1036,6 +1036,15 @@ public partial class MainWindowViewModel : ViewModelBase
             // the ClientID (UUID) field in the GUIClient objects. Wait a moment for these to arrive.
             Thread.Sleep(500);
 
+            // Verify radio is still connected (defensive check)
+            if (_connectedRadio == null)
+            {
+                RadioStatus = "Radio connection was lost unexpectedly";
+                RadioStatusColor = Brushes.Red;
+                HasRadioError = true;
+                return;
+            }
+
             // Look up the updated GUIClient from the connected radio's GuiClients list
             // This will now have the ClientID (UUID) populated
             GUIClient updatedGuiClient = _connectedRadio.FindGUIClientByClientHandle(targetClientHandle);
@@ -1467,7 +1476,9 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             case "CWSpeed":
                 if (e.Value is int cwSpeed && CwSpeed != cwSpeed)
+                {
                     CwSpeed = cwSpeed;
+                }
                 break;
 
             case "CWPitch":


### PR DESCRIPTION
Tried many different ways but unable to get both NetKeyer and SmartSDR be able to change CW parameters. 
It is not possible to distinguish the SDR response from profile response which is what is causing the snap to 30 WPM.
There can only be "one authority" and it make sense in this case to make NetKeyer the authority. When running NetKeyer you must use it UI to change CW parameters. When try to change on SDR they are snapped back to the NetKeyer values. This is acceptable. When exit NetKeyer, SDR now assumes control. All good. 
Have tested these changes on new PCs and old and work fine. Need to remember to install the VS C++ runtime libraries before use, but that is not this PRs issue. 
