### PR TITLE
Fix #48: wait for GUIClient UUID before binding over SmartLink

### DIFF
--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1032,13 +1032,22 @@ public partial class MainWindowViewModel : ViewModelBase
                 return;
             }
 
-            // After Connect(), the radio sends "client connected" status messages that populate
-            // the ClientID (UUID) field in the GUIClient objects. Wait a moment for these to arrive.
-            Thread.Sleep(500);
-
-            // Look up the updated GUIClient from the connected radio's GuiClients list
-            // This will now have the ClientID (UUID) populated
-            GUIClient updatedGuiClient = _connectedRadio.FindGUIClientByClientHandle(targetClientHandle);
+            // After Connect(), the radio asynchronously populates each GUIClient's ClientID (UUID).
+            // Binding before it arrives sends an empty client_id, which leaves this client unbound
+            // while the radio serves a default keyer context (issue #48). Over SmartLink the UUID can
+            // take ~1s, so wait for it instead of a fixed delay, and never bind with an empty UUID.
+            GUIClient updatedGuiClient = null;
+            string clientId = null;
+            var uuidWait = System.Diagnostics.Stopwatch.StartNew();
+            const int uuidTimeoutMs = 5000;
+            while (uuidWait.ElapsedMilliseconds < uuidTimeoutMs)
+            {
+                updatedGuiClient = _connectedRadio.FindGUIClientByClientHandle(targetClientHandle);
+                clientId = updatedGuiClient?.ClientID;
+                if (!string.IsNullOrEmpty(clientId))
+                    break;
+                Thread.Sleep(50);
+            }
 
             if (updatedGuiClient == null)
             {
@@ -1050,18 +1059,20 @@ public partial class MainWindowViewModel : ViewModelBase
                 return;
             }
 
-            string clientId = updatedGuiClient.ClientID;
             if (string.IsNullOrEmpty(clientId))
             {
-                RadioStatus = "Client UUID not available - binding may fail";
-                RadioStatusColor = Brushes.Orange;
+                // UUID never arrived: an empty bind would leave the keyer on the radio default.
+                // Fail cleanly and let the user retry rather than connecting in a broken state.
+                RadioStatus = "Station UUID not received - could not bind. Please retry.";
+                RadioStatusColor = Brushes.Red;
                 HasRadioError = true;
+                _connectedRadio.Disconnect();
+                _connectedRadio = null;
+                return;
             }
-            else
-            {
-                // Clear any previous errors on successful connection
-                HasRadioError = false;
-            }
+
+            // Clear any previous errors on successful connection
+            HasRadioError = false;
 
             // Bind to the selected station using its UUID
             _connectedRadio.BindGUIClient(clientId);


### PR DESCRIPTION
On SmartLink and other slow connections, the CW keyer mode and speed would intermittently revert to the radio's default (30 WPM / Iambic) right after connecting, instead of honoring the station's Straight Key / WPM. The cause was a timing race in the bind step: the radio populates each GUI client's UUID asynchronously after Connect(), but NetKeyer waited only a fixed 500 ms before binding. Over SmartLink the UUID typically arrives ~1 second later, so the bind often went out with an empty client_id, leaving NetKeyer unbound and the radio serving its default keyer context. (Pitch and sidetone were unaffected since those are global, while keyer speed and mode are scoped to the bound client.) This replaces the fixed delay with a short wait for the UUID to arrive before binding, and never binds with an empty UUID. Tested over SmartLink across repeated reconnects on both SmartSDR and Maestro clients, and on direct LAN. Fixes #48.
